### PR TITLE
Update: correct log file name in webapp.py

### DIFF
--- a/webapp.py
+++ b/webapp.py
@@ -414,7 +414,7 @@ def api_users():
 def logs():
     """View logs"""
     try:
-        log_file = '/app/logs/vibecodeplugin.log'
+        log_file = '/app/logs/jellyjams.log'
         if Path(log_file).exists():
             with open(log_file, 'r') as f:
                 log_content = f.read()


### PR DESCRIPTION
Logs are written to /app/logs/jellyjams.log, but webapp.py was trying to read logs in /app/logs/vibecodeplugin.log. The log file name has been corrected and logs now appear in the webUI.