### PR TITLE
Fix: use WEB_PORT variable in docker port mapping

### DIFF
--- a/docker-compose-unraid.yml
+++ b/docker-compose-unraid.yml
@@ -40,5 +40,5 @@ services:
       # Music directory for cover art generation (adjust path for your system)
       - /mnt/user/media/data/music:/mnt/user/media/data/music:ro
     ports:
-      - "5000:5000"
+      - "${WEB_PORT}:5000"
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       # Music directory for cover art generation (adjust path for your system)
       - /mnt/user/media/data/music:/mnt/user/media/data/music:ro
     ports:
-      - "5000:5000"
+      - "${WEB_PORT}:5000"
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
Use the WEB_PORT variable in the docker container port mapping so that it doesn't need to be edited separately.